### PR TITLE
Fix window ordering flickering

### DIFF
--- a/src/app.reducer.ts
+++ b/src/app.reducer.ts
@@ -56,27 +56,36 @@ export function reducer(state: AppState, action: Action) {
         ),
       };
     case FOCUS_WINDOW:
-      const filteredAndResetted = state.activeWindows
-        .filter((aw) => aw.name !== action.payload.name)
-        .map((v) => ({ ...v, focused: false }));
-
       const maxZIndex = Math.max(
-        ...filteredAndResetted.map((x) => x.zIndex),
+        ...state.activeWindows.map((x) => x.zIndex),
         INITIAL_ZINDEX
       );
-      const activeWindows = [
-        {
+
+      const refocusedWindows = state.activeWindows.map((aw) => {
+        if (aw.name === action.payload.name) {
+          return {
+            ...aw,
+            zIndex: maxZIndex + 1,
+            focused: true,
+          };
+        }
+
+        return { ...aw, focused: false };
+      });
+
+      // We need to open a new window:
+      if (!refocusedWindows.find(({ name }) => name === action.payload.name)) {
+        refocusedWindows.push({
           name: action.payload.name,
           defaultUrl: action.payload.defaultUrl,
           zIndex: maxZIndex + 1,
           focused: true,
-        },
-        ...filteredAndResetted,
-      ];
+        });
+      }
 
       return {
         ...state,
-        activeWindows,
+        activeWindows: refocusedWindows,
       };
     default:
       throw new Error();

--- a/src/components/Window.tsx
+++ b/src/components/Window.tsx
@@ -217,7 +217,7 @@ const Window: FC<WindowProps> = React.memo(({ name, minimizedTargetRect }) => {
             handleMaximizeClick={handleMaximizeClick}
           />
         </div>
-        <Component key={`${name}`} />
+        <Component key={name} />
       </span>
     </Rnd>
   );


### PR DESCRIPTION
The problem was the re-ordering of dom nodes, which caused the iframe to think it was brand new. Easy fix was to not re-order DOM nodes.